### PR TITLE
Lists T2 connections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,28 @@ Every time a reading is made (using the `.read()` function or through the `.poll
 ![](https://lh6.googleusercontent.com/-rouT78pE2_U/VKG0f_RF3QI/AAAAAAAALpQ/B_sAqWNMatE/w926-h521-no/20141229_110637.jpg)
 ![](https://lh4.googleusercontent.com/-2mD7RGs3eyU/VKG0eyNzfbI/AAAAAAAALpE/_NUo1dzSxsE/w926-h521-no/20141229_110617.jpg)
 
-The thermocouple talks over [SPI](https://github.com/tessel/docs/blob/master/tutorials/communication-protocols.md#spi), so we need to connect chip select, clock, and data, as well as power and ground. From the thermocouple amplifier to Tessel's GPIO bank:
+The thermocouple talks over [SPI](https://github.com/tessel/docs/blob/master/tutorials/communication-protocols.md#spi), so we need to connect chip select, clock, and data, as well as power and ground.
+
+### T1
+
+From the thermocouple amplifier to Tessel's GPIO bank:
   * Vin > 3.3V (power)
   * 3Vo > nothing, we don't need this one
   * GND > GND (ground)
   * DO > MISO (this is data from the thermocouple coming in to Tessel)
   * CS > TX/G1 (chip select– we're using a digital GPIO pin to tell the amplifier when we're talking to it)
   * CLK > SCK (different names for the clock pin)
+ 
+### T2
 
+From the thermocouple amplifier to Tessel's Port bank:
+  * Vin > 3.3V (power)
+  * 3Vo > nothing, we don't need this one
+  * GND > GND (ground)
+  * DO > 3
+  * CS > 5
+  * CLK > 2
+ 
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ From the thermocouple amplifier to Tessel's Port bank:
   * DO > 3
   * CS > 5
   * CLK > 2
+  
+  Note: These connections are in the same location as they are on the Tessel 1. You can also see the original
+    labels on the underside of the T2.
  
 ## License
 


### PR DESCRIPTION
The T2 connections are not labeled the same as the T1. The module works great, but the
connections needed an update. I used the current T2 port documentation and tested the
module. Everything looks great.

Amos King @adkron amos@binarynoggin.com
